### PR TITLE
Fixed header to get api endpoint when debugging with fiddler

### DIFF
--- a/Pokecon/Program.cs
+++ b/Pokecon/Program.cs
@@ -65,6 +65,7 @@ namespace Pokecon
                     envelop.Requests.Add(r);
                 using (var client = new HttpClient())
                 {
+                    client.DefaultRequestHeaders.ExpectContinue = false;
                     client.DefaultRequestHeaders.Add("User-Agent", "Niantic App");
                     using (var ms = new MemoryStream())
                     {


### PR DESCRIPTION
When debugging in fiddler it will place this expect 100-continue.  This just allows for easier debugging.
